### PR TITLE
Update base image to buster.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,7 @@ ADD        . /go/src/github.com/proofpoint/certificate-init-container
 RUN        go install github.com/proofpoint/certificate-init-container && \
            go test github.com/proofpoint/certificate-init-container/...
 
-FROM debian:9.8-slim
-
-RUN apt-get update && \
-   DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes \
-                    # These packages are security updates
-                    tzdata=2019a-0+deb9u1
+FROM debian:10.0-slim
 
 COPY --from=0 /go/bin/certificate-init-container .
 ENTRYPOINT ["/certificate-init-container"]


### PR DESCRIPTION
This PR updates the base image from debian 9.8 to 10.0.

Clair flags a number of high severity CVEs, some of which are not fixed on stretch, but are addressed in buster (stable) and sid (unstable).

*note* `10.0` ships with `tzdata/now 2019a-1`

| CVE | Severity | Package | Version |
| ---- | -------- | -------- | --------|
| [CVE-2019-12900](https://security-tracker.debian.org/tracker/CVE-2019-12900)     | High | bzip2      | 1.0.6-8.1       |
| [CVE-2019-9169](https://security-tracker.debian.org/tracker/CVE-2019-9169)       | High | glibc      | 2.24-11+deb9u4  |
| [CVE-2018-6551](https://security-tracker.debian.org/tracker/CVE-2018-6551)       | High | glibc      | 2.24-11+deb9u4  |
| [CVE-2018-1000001](https://security-tracker.debian.org/tracker/CVE-2018-1000001) | High | glibc      | 2.24-11+deb9u4  |
| [CVE-2018-6485](https://security-tracker.debian.org/tracker/CVE-2018-6485)       | High | glibc      | 2.24-11+deb9u4  |
| [CVE-2016-2779](https://security-tracker.debian.org/tracker/CVE-2016-2779)       | High | util-linux | 2.29.2-1+deb9u1 |
| [CVE-2018-15686](https://security-tracker.debian.org/tracker/CVE-2018-15686)     | High | systemd    | 232-25+deb9u9   |
| [CVE-2017-12424](https://security-tracker.debian.org/tracker/CVE-2017-12424)     | High | shadow     | 1:4.4-4.1       |

I have verified this locally using the provided tls-app.yaml example.

```
$ k apply -f deployments/tls-app.yaml -n cert-init

$ k certificate approve tls-app-84d69899b4-9ck8f-cert-init-0xvta
certificatesigningrequest.certificates.k8s.io/tls-app-84d69899b4-9ck8f-cert-init-0xvta approved

$ k get pods -n cert-init -w
NAME                       READY   STATUS    RESTARTS   AGE
tls-app-84d69899b4-9ck8f   1/1     Running   0          79s
```